### PR TITLE
Add requisitos para rodar no Codecov.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,3 +30,13 @@ jobs:
       - name: Test with pytest
         run: |
           python -m pytest
+      - name: Generate coverage report
+        run: |
+          pip install pytest
+          pip install pytest-cov
+          pytest --cov=./ --cov-report=xml
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos


### PR DESCRIPTION
Espero que funcione.

Ele tá sem o arquivo:  .coveragerc e sem o cover.py

Preciso entender o tutorial de cobertura a partir dessa parte:
https://github.com/codecov/example-python#produce-coverage-reports.